### PR TITLE
fix: correct login HTTP status codes and messages

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -28,13 +28,9 @@ class AuthController extends Controller
      */
     public function adminLogin(LoginRequest $request): JsonResponse
     {
-        try {
-            $result = $this->authService->adminLogin($request->validated());
+        $result = $this->authService->adminLogin($request->validated());
 
-            return $this->success($result, 'Login successful');
-        } catch (\Exception $e) {
-            return $this->error($e->getMessage(), 422);
-        }
+        return $this->success($result, 'Login successful');
     }
 
     /**

--- a/app/Services/Implementations/AuthService.php
+++ b/app/Services/Implementations/AuthService.php
@@ -7,6 +7,8 @@ use App\Repositories\Interfaces\AuthRepositoryInterface;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\AuthenticationException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class AuthService implements AuthServiceInterface
 {
@@ -25,15 +27,11 @@ class AuthService implements AuthServiceInterface
         $admin = $this->authRepository->findAdminByEmail($credentials['email']);
 
         if (!$admin || !Hash::check($credentials['password'], $admin->password)) {
-            throw ValidationException::withMessages([
-                'email' => ['Invalid credentials.'],
-            ]);
+            abort(401, 'Invalid credentials.');
         }
 
         if (!$admin->is_active) {
-            throw ValidationException::withMessages([
-                'email' => ['Account is inactive.'],
-            ]);
+            abort(401, 'Account is inactive.');
         }
 
         $this->authRepository->updateAdminLastLogin($admin);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,11 +15,21 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        $exceptions->render(function (\Symfony\Component\HttpKernel\Exception\HttpException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'status' => 'error',
+                    'message' => $e->getMessage() ?: 'An error occurred',
+                    'errors' => null,
+                ], $e->getStatusCode());
+            }
+        });
+
         $exceptions->render(function (\Illuminate\Auth\AuthenticationException $e, $request) {
             if ($request->expectsJson()) {
                 return response()->json([
                     'status' => 'error',
-                    'message' => 'Unauthenticated',
+                    'message' => $e->getMessage() ?: 'Unauthenticated',
                     'errors' => null,
                 ], 401);
             }
@@ -39,7 +49,7 @@ return Application::configure(basePath: dirname(__DIR__))
             if ($request->is('api/*')) {
                 return response()->json([
                     'status' => 'error',
-                    'message' => 'Resource not found',
+                    'message' => $e->getMessage() ?: 'Resource not found',
                     'errors' => null,
                 ], 404);
             }
@@ -49,7 +59,7 @@ return Application::configure(basePath: dirname(__DIR__))
             if ($request->is('api/*')) {
                 return response()->json([
                     'status' => 'error',
-                    'message' => 'Access denied',
+                    'message' => $e->getMessage() ?: 'Access denied',
                     'errors' => null,
                 ], 403);
             }


### PR DESCRIPTION
### Summary
- Updated AuthService to return 401 Unauthorized instead of 422 Validation Error when credentials are invalid or account is inactive.
- Used bort(401, '...') to ensure specific error messages are returned and to prevent Octane/FrankenPHP redirection hangs.
- Refactored AuthController@adminLogin to allow global exception handling.
- Enhanced ootstrap/app.php exception rendering to provide consistent JSON responses with dynamic error messages for HttpException, AuthenticationException, NotFoundHttpException, and AccessDeniedHttpException.
