### PR TITLE
feat(banners): implement full CRUD with cloudflare r2 integration

### DIFF
--- a/app/Http/Controllers/Api/BannerController.php
+++ b/app/Http/Controllers/Api/BannerController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreBannerRequest;
+use App\Http\Requests\Api\UpdateBannerRequest;
+use App\Http\Resources\BannerResource;
 use App\Services\Interfaces\BannerServiceInterface;
 use App\Traits\ApiResponse;
 use Illuminate\Http\JsonResponse;
@@ -31,7 +34,25 @@ class BannerController extends Controller
         $perPage = $request->query('per_page', 10);
         $banners = $this->bannerService->getAllBanners($perPage);
 
-        return $this->successWithPagination($banners, 'Banners retrieved successfully');
+        return $this->successWithPagination(BannerResource::collection($banners), 'Banners retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param StoreBannerRequest $request
+     * @return JsonResponse
+     */
+    public function store(StoreBannerRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image'] = $request->file('image');
+        }
+        
+        $banner = $this->bannerService->createBanner($data);
+
+        return $this->success(new BannerResource($banner), 'Banner created successfully', 201);
     }
 
     /**
@@ -44,9 +65,53 @@ class BannerController extends Controller
     {
         try {
             $banner = $this->bannerService->getBannerById($id);
-            return $this->success($banner, 'Banner retrieved successfully');
+            $banner->load('placements');
+            return $this->success(new BannerResource($banner), 'Banner retrieved successfully');
         } catch (ModelNotFoundException $e) {
             return $this->error($e->getMessage(), 404);
+        } catch (\Exception $e) {
+            return $this->error($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param UpdateBannerRequest $request
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function update(UpdateBannerRequest $request, int $id): JsonResponse
+    {
+        try {
+            $data = $request->validated();
+            if ($request->hasFile('image')) {
+                $data['image'] = $request->file('image');
+            }
+            
+            $banner = $this->bannerService->updateBanner($id, $data);
+
+            return $this->success(new BannerResource($banner), 'Banner updated successfully');
+        } catch (ModelNotFoundException $e) {
+            return $this->error("Banner with ID {$id} not found.", 404);
+        } catch (\Exception $e) {
+            return $this->error($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $this->bannerService->deleteBanner($id);
+            return $this->success(null, 'Banner deleted successfully');
+        } catch (ModelNotFoundException $e) {
+            return $this->error("Banner with ID {$id} not found.", 404);
         } catch (\Exception $e) {
             return $this->error($e->getMessage(), 500);
         }
@@ -65,6 +130,6 @@ class BannerController extends Controller
         
         $banners = $this->bannerService->searchBanners($keyword, $perPage);
 
-        return $this->successWithPagination($banners, 'Banners search results retrieved successfully');
+        return $this->successWithPagination(BannerResource::collection($banners), 'Banners search results retrieved successfully');
     }
 }

--- a/app/Http/Requests/Api/StoreBannerRequest.php
+++ b/app/Http/Requests/Api/StoreBannerRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Http\Requests\BaseRequest;
+
+class StoreBannerRequest extends BaseRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'image' => 'required|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'link_url' => 'nullable|url',
+            'is_active' => 'boolean',
+            'start_at' => 'nullable|date',
+            'end_at' => 'nullable|date|after_or_equal:start_at',
+            'order_index' => 'integer',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateBannerRequest.php
+++ b/app/Http/Requests/Api/UpdateBannerRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Http\Requests\BaseRequest;
+
+class UpdateBannerRequest extends BaseRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'sometimes|required|string|max:255',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'link_url' => 'nullable|url',
+            'is_active' => 'boolean',
+            'start_at' => 'nullable|date',
+            'end_at' => 'nullable|date|after_or_equal:start_at',
+            'order_index' => 'integer',
+        ];
+    }
+}

--- a/app/Http/Resources/BannerPlacementResource.php
+++ b/app/Http/Resources/BannerPlacementResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class BannerPlacementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'placement' => $this->placement,
+        ];
+    }
+}

--- a/app/Http/Resources/BannerResource.php
+++ b/app/Http/Resources/BannerResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class BannerResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'image_url' => $this->image_url,
+            'link_url' => $this->link_url,
+            'is_active' => $this->is_active,
+            'start_at' => $this->start_at?->toDateTimeString(),
+            'end_at' => $this->end_at?->toDateTimeString(),
+            'order_index' => $this->order_index,
+            'placements' => BannerPlacementResource::collection($this->whenLoaded('placements')),
+        ];
+    }
+}

--- a/app/Repositories/Implementations/BannerRepository.php
+++ b/app/Repositories/Implementations/BannerRepository.php
@@ -32,4 +32,31 @@ class BannerRepository implements BannerRepositoryInterface
         return Banner::where('title', 'like', "%{$keyword}%")
             ->paginate($perPage);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $data): Banner
+    {
+        return Banner::create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(int $id, array $data): Banner
+    {
+        $banner = Banner::findOrFail($id);
+        $banner->update($data);
+        return $banner;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(int $id): bool
+    {
+        $banner = Banner::findOrFail($id);
+        return $banner->delete();
+    }
 }

--- a/app/Repositories/Interfaces/BannerRepositoryInterface.php
+++ b/app/Repositories/Interfaces/BannerRepositoryInterface.php
@@ -24,11 +24,36 @@ interface BannerRepositoryInterface
     public function findById(int $id): ?Banner;
 
     /**
-     * Search banners by keyword.
+     * Search banners.
      *
      * @param string $keyword
      * @param int $perPage
      * @return LengthAwarePaginator
      */
     public function search(string $keyword, int $perPage): LengthAwarePaginator;
-}
+
+    /**
+     * Create a new banner.
+     *
+     * @param array $data
+     * @return Banner
+     */
+    public function create(array $data): Banner;
+
+    /**
+     * Update an existing banner.
+     *
+     * @param int $id
+     * @param array $data
+     * @return Banner
+     */
+    public function update(int $id, array $data): Banner;
+
+    /**
+     * Delete a banner.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function delete(int $id): bool;
+    }

--- a/app/Services/Implementations/BannerService.php
+++ b/app/Services/Implementations/BannerService.php
@@ -7,6 +7,10 @@ use App\Repositories\Interfaces\BannerRepositoryInterface;
 use App\Services\Interfaces\BannerServiceInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\UploadedFile;
+
+use Illuminate\Support\Str;
 
 class BannerService implements BannerServiceInterface
 {
@@ -45,5 +49,70 @@ class BannerService implements BannerServiceInterface
     public function searchBanners(string $keyword, int $perPage): LengthAwarePaginator
     {
         return $this->bannerRepository->search($keyword, $perPage);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createBanner(array $data): Banner
+    {
+        if (isset($data['image']) && $data['image'] instanceof UploadedFile) {
+            $filename = Str::uuid() . '.' . $data['image']->getClientOriginalExtension();
+            $path = $data['image']->storeAs('banners', $filename, 'r2');
+            $data['image_url'] = Storage::disk('r2')->url($path);
+            unset($data['image']);
+        }
+
+        return $this->bannerRepository->create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateBanner(int $id, array $data): Banner
+    {
+        if (isset($data['image']) && $data['image'] instanceof UploadedFile) {
+            $banner = $this->getBannerById($id);
+            if ($banner->image_url) {
+                $this->deleteFileFromR2($banner->image_url);
+            }
+
+            $filename = Str::uuid() . '.' . $data['image']->getClientOriginalExtension();
+            $path = $data['image']->storeAs('banners', $filename, 'r2');
+            $data['image_url'] = Storage::disk('r2')->url($path);
+            unset($data['image']);
+        }
+
+        return $this->bannerRepository->update($id, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteBanner(int $id): bool
+    {
+        $banner = $this->getBannerById($id);
+        if ($banner->image_url) {
+            $this->deleteFileFromR2($banner->image_url);
+        }
+
+        return $this->bannerRepository->delete($id);
+    }
+
+    /**
+     * Delete file from R2 by URL.
+     *
+     * @param string $url
+     * @return void
+     */
+    protected function deleteFileFromR2(string $url): void
+    {
+        $baseUrl = Storage::disk('r2')->url('');
+        $path = str_replace($baseUrl, '', $url);
+        $path = ltrim($path, '/');
+        
+        if ($path) {
+            Storage::disk('r2')->delete($path);
+        }
     }
 }

--- a/app/Services/Interfaces/BannerServiceInterface.php
+++ b/app/Services/Interfaces/BannerServiceInterface.php
@@ -31,4 +31,29 @@ interface BannerServiceInterface
      * @return LengthAwarePaginator
      */
     public function searchBanners(string $keyword, int $perPage): LengthAwarePaginator;
+
+    /**
+     * Create a new banner.
+     *
+     * @param array $data
+     * @return Banner
+     */
+    public function createBanner(array $data): Banner;
+
+    /**
+     * Update an existing banner.
+     *
+     * @param int $id
+     * @param array $data
+     * @return Banner
+     */
+    public function updateBanner(int $id, array $data): Banner;
+
+    /**
+     * Delete a banner.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function deleteBanner(int $id): bool;
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/octane": "*",
         "laravel/socialite": "^5.26",
         "laravel/tinker": "^3.0",
+        "league/flysystem-aws-s3-v3": "^3.0",
         "tymon/jwt-auth": "^2.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8179383acf7d7c422120b9c1a0f039b",
+    "content-hash": "e8f366e73e540a9517e8f6dec8d667fd",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.381.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "9be3422631494111ec76bec677f1ae2dec650573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9be3422631494111ec76bec677f1ae2dec650573",
+                "reference": "9be3422631494111ec76bec677f1ae2dec650573",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.381.6"
+            },
+            "time": "2026-05-21T20:14:47+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -707,16 +858,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
                 "shasum": ""
             },
             "require": {
@@ -734,8 +885,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.3.2",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -813,7 +965,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.3"
             },
             "funding": [
                 {
@@ -829,20 +981,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-05-20T22:59:19+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +1002,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -896,7 +1048,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
             },
             "funding": [
                 {
@@ -912,20 +1064,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-05-20T22:57:30+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
                 "shasum": ""
             },
             "require": {
@@ -940,9 +1092,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1013,7 +1165,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
             },
             "funding": [
                 {
@@ -1029,7 +1181,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-05-20T09:27:36+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -2042,16 +2194,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.33.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "570b8871e0ce693764434b29154c54b434905350"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/570b8871e0ce693764434b29154c54b434905350",
-                "reference": "570b8871e0ce693764434b29154c54b434905350",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -2119,9 +2271,64 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.33.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-03-25T07:59:30+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
+        },
+        {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.371.5",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.34.0"
+            },
+            "time": "2026-05-04T08:24:00+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2588,6 +2795,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+            },
+            "time": "2024-09-04T18:46:31+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -4228,16 +4501,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -4250,7 +4523,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4275,7 +4548,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -4287,11 +4560,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -4534,6 +4811,76 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:39:47+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4955,7 +5302,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -5014,7 +5361,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5120,7 +5467,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -5183,7 +5530,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5207,7 +5554,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5268,7 +5615,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5292,7 +5639,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -5353,7 +5700,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5377,7 +5724,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -5437,7 +5784,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5704,16 +6051,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.8",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
                 "shasum": ""
             },
             "require": {
@@ -5745,7 +6092,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -5765,7 +6112,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-11T16:56:32+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -60,6 +60,19 @@ return [
             'report' => false,
         ],
 
+        'r2' => [
+            'driver' => 's3',
+            'key' => env('R2_ACCESS_KEY_ID'),
+            'secret' => env('R2_SECRET_ACCESS_KEY'),
+            'region' => env('R2_DEFAULT_REGION', 'auto'),
+            'bucket' => env('R2_BUCKET'),
+            'url' => env('R2_URL'),
+            'endpoint' => env('R2_ENDPOINT'),
+            'use_path_style_endpoint' => true,
+            'throw' => false,
+            'report' => false,
+        ],
+
     ],
 
     /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,13 @@ Route::prefix('auth')->group(function () {
             Route::put('/{tag}', [TagController::class, 'update']);
             Route::delete('/{tag}', [TagController::class, 'destroy']);
         });
+
+        // Banners
+        Route::prefix('banners')->group(function () {
+            Route::post('/', [BannerController::class, 'store']);
+            Route::put('/{banner}', [BannerController::class, 'update']);
+            Route::delete('/{banner}', [BannerController::class, 'destroy']);
+        });
     });
 });
 

--- a/tests/Feature/BannerTest.php
+++ b/tests/Feature/BannerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use App\Models\Banner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class BannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_banners()
+    {
+        Banner::create([
+            'title' => 'Banner 1',
+            'image_url' => 'https://example.com/1.jpg',
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson('/api/banners');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['id', 'title', 'image_url', 'is_active']
+                ]
+            ]);
+    }
+
+    public function test_admin_can_create_banner_with_r2_upload()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $file = UploadedFile::fake()->image('banner.jpg');
+        $data = [
+            'title' => 'Promo Banner',
+            'image' => $file,
+            'is_active' => true,
+        ];
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->postJson('/api/auth/banners', $data);
+
+        $response->assertStatus(201);
+        
+        $banner = Banner::first();
+        $this->assertNotNull($banner->image_url);
+        $this->assertStringContainsString('banners/', $banner->image_url);
+        
+        // Extract filename from URL since it's now a UUID
+        $filename = basename($banner->image_url);
+        Storage::disk('r2')->assertExists('banners/' . $filename);
+    }
+
+    public function test_admin_can_update_banner_with_new_image()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $banner = Banner::create([
+            'title' => 'Old Title',
+            'image_url' => 'https://example.com/old.jpg',
+        ]);
+
+        $file = UploadedFile::fake()->image('new_banner.jpg');
+        $data = [
+            'title' => 'New Title',
+            'image' => $file,
+        ];
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->putJson("/api/auth/banners/{$banner->id}", $data);
+
+        $response->assertStatus(200);
+        
+        $banner->refresh();
+        $this->assertEquals('New Title', $banner->title);
+        $this->assertStringContainsString('.jpg', $banner->image_url);
+        
+        $filename = basename($banner->image_url);
+        Storage::disk('r2')->assertExists('banners/' . $filename);
+    }
+
+    public function test_admin_can_delete_banner_and_image_from_r2()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $path = 'banners/test.jpg';
+        Storage::disk('r2')->put($path, 'content');
+        $url = Storage::disk('r2')->url($path);
+
+        $banner = Banner::create([
+            'title' => 'To be deleted',
+            'image_url' => $url,
+        ]);
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->deleteJson("/api/auth/banners/{$banner->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('banners', ['id' => $banner->id]);
+        Storage::disk('r2')->assertMissing($path);
+    }
+}

--- a/tests/Unit/Http/Controllers/Api/BannerControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/BannerControllerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Unit\Http\Controllers\Api;
+
+use App\Models\Admin;
+use App\Models\Banner;
+use App\Services\Interfaces\BannerServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Mockery\MockInterface;
+use Mockery;
+use Tests\TestCase;
+
+class BannerControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_success_response()
+    {
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) {
+            $paginator = new LengthAwarePaginator(collect([]), 0, 10);
+            $mock->shouldReceive('getAllBanners')->once()->with(10)->andReturn($paginator);
+        });
+
+        $response = $this->getJson('/api/banners?per_page=10');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'Banners retrieved successfully'
+            ]);
+    }
+
+    public function test_show_returns_success_response()
+    {
+        $banner = new Banner(['title' => 'Test Banner', 'image_url' => 'https://r2.com/test.jpg']);
+        $banner->id = 1;
+
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) use ($banner) {
+            $mock->shouldReceive('getBannerById')->once()->with(1)->andReturn($banner);
+        });
+
+        $response = $this->getJson('/api/banners/1');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    'id' => 1,
+                    'title' => 'Test Banner'
+                ]
+            ]);
+    }
+
+    public function test_store_returns_success_response()
+    {
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+        
+        $bannerData = [
+            'title' => 'New Banner',
+            'is_active' => true,
+        ];
+        
+        $banner = new Banner(array_merge(['id' => 1, 'image_url' => 'https://r2.com/new.jpg'], $bannerData));
+        $banner->id = 1;
+
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) use ($banner) {
+            $mock->shouldReceive('createBanner')->once()->andReturn($banner);
+        });
+
+        // Use UploadedFile to satisfy request validation
+        $file = \Illuminate\Http\UploadedFile::fake()->image('banner.jpg');
+        
+        $response = $this->actingAs($admin, 'admin-api')
+            ->postJson('/api/auth/banners', array_merge($bannerData, ['image' => $file]));
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'Banner created successfully',
+                'data' => ['title' => 'New Banner']
+            ]);
+    }
+
+    public function test_update_returns_success_response()
+    {
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+        
+        $bannerData = ['title' => 'Updated Banner'];
+        $banner = new Banner(array_merge(['id' => 1, 'image_url' => 'https://r2.com/updated.jpg'], $bannerData));
+        $banner->id = 1;
+
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) use ($banner) {
+            $mock->shouldReceive('updateBanner')->once()->with(1, Mockery::any())->andReturn($banner);
+        });
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->putJson('/api/auth/banners/1', $bannerData);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Banner updated successfully',
+                'data' => ['title' => 'Updated Banner']
+            ]);
+    }
+
+    public function test_destroy_returns_success_response()
+    {
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) {
+            $mock->shouldReceive('deleteBanner')->once()->with(1)->andReturn(true);
+        });
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->deleteJson('/api/auth/banners/1');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Banner deleted successfully'
+            ]);
+    }
+
+    public function test_search_returns_success_response()
+    {
+        $this->mock(BannerServiceInterface::class, function (MockInterface $mock) {
+            $paginator = new LengthAwarePaginator(collect([]), 0, 10);
+            $mock->shouldReceive('searchBanners')->once()->with('test', 10)->andReturn($paginator);
+        });
+
+        $response = $this->getJson('/api/banners/search?keyword=test&per_page=10');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Banners search results retrieved successfully'
+            ]);
+    }
+}

--- a/tests/Unit/Services/BannerServiceTest.php
+++ b/tests/Unit/Services/BannerServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Banner;
+use App\Repositories\Interfaces\BannerRepositoryInterface;
+use App\Services\Implementations\BannerService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class BannerServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_create_banner_uploads_to_r2()
+    {
+        Storage::fake('r2');
+        $file = UploadedFile::fake()->image('banner.png');
+        
+        $data = [
+            'title' => 'Test Banner',
+            'image' => $file
+        ];
+
+        $capturedData = [];
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use (&$capturedData) {
+            $mock->shouldReceive('create')
+                ->once()
+                ->with(Mockery::on(function($arg) use (&$capturedData) {
+                    $capturedData = $arg;
+                    return $arg['title'] === 'Test Banner' && isset($arg['image_url']);
+                }))
+                ->andReturn(new Banner());
+        });
+
+        $service = app(BannerService::class);
+        $service->createBanner($data);
+        
+        $filename = basename($capturedData['image_url']);
+        Storage::disk('r2')->assertExists('banners/' . $filename);
+    }
+
+    public function test_get_all_banners_returns_paginated_data()
+    {
+        $perPage = 10;
+        $mockPaginator = Mockery::mock(LengthAwarePaginator::class);
+
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use ($mockPaginator, $perPage) {
+            $mock->shouldReceive('getAllPaginated')
+                ->once()
+                ->with($perPage)
+                ->andReturn($mockPaginator);
+        });
+
+        $service = app(BannerService::class);
+        $result = $service->getAllBanners($perPage);
+
+        $this->assertSame($mockPaginator, $result);
+    }
+
+    public function test_get_banner_by_id_returns_banner()
+    {
+        $bannerId = 1;
+        $mockBanner = new Banner(['id' => $bannerId]);
+
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use ($bannerId, $mockBanner) {
+            $mock->shouldReceive('findById')
+                ->once()
+                ->with($bannerId)
+                ->andReturn($mockBanner);
+        });
+
+        $service = app(BannerService::class);
+        $result = $service->getBannerById($bannerId);
+
+        $this->assertSame($mockBanner, $result);
+    }
+
+    public function test_update_banner_calls_repository()
+    {
+        $bannerId = 1;
+        $data = ['title' => 'Updated Title'];
+        $mockBanner = new Banner(array_merge(['id' => $bannerId], $data));
+
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use ($bannerId, $data, $mockBanner) {
+            $mock->shouldReceive('update')
+                ->once()
+                ->with($bannerId, $data)
+                ->andReturn($mockBanner);
+        });
+
+        $service = app(BannerService::class);
+        $result = $service->updateBanner($bannerId, $data);
+
+        $this->assertSame($mockBanner, $result);
+    }
+
+    public function test_delete_banner_calls_repository()
+    {
+        $bannerId = 1;
+        $mockBanner = new Banner(['id' => $bannerId, 'image_url' => null]);
+
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use ($bannerId, $mockBanner) {
+            $mock->shouldReceive('findById')->andReturn($mockBanner);
+            $mock->shouldReceive('delete')->once()->with($bannerId)->andReturn(true);
+        });
+
+        $service = app(BannerService::class);
+        $result = $service->deleteBanner($bannerId);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_search_banners_calls_repository()
+    {
+        $keyword = 'promo';
+        $perPage = 10;
+        $mockPaginator = Mockery::mock(LengthAwarePaginator::class);
+
+        $this->mock(BannerRepositoryInterface::class, function (MockInterface $mock) use ($keyword, $perPage, $mockPaginator) {
+            $mock->shouldReceive('search')
+                ->once()
+                ->with($keyword, $perPage)
+                ->andReturn($mockPaginator);
+        });
+
+        $service = app(BannerService::class);
+        $result = $service->searchBanners($keyword, $perPage);
+
+        $this->assertSame($mockPaginator, $result);
+    }
+}


### PR DESCRIPTION
## Description
Implemented full CRUD functionality for Banners with Cloudflare R2 integration for image storage.

## Changes
- Installed league/flysystem-aws-s3-v3 for R2 compatibility.
- Configured 2 disk in config/filesystems.php.
- Implemented BannerRepository and BannerService with R2 upload/delete logic.
- Implemented BannerController with BannerResource and Store/UpdateBannerRequest.
- Added UUID-based filenames for uploaded images.
- Ensured automatic deletion of old images on update/delete.

## Testing
- **Feature Tests**: 	ests/Feature/BannerTest.php (Integration with R2 fake storage).
- **Unit Tests (Service)**: 	ests/Unit/Services/BannerServiceTest.php (Mocked repository).
- **Unit Tests (Controller)**: 	ests/Unit/Http/Controllers/Api/BannerControllerTest.php (Mocked service).
- Total tests passing: 57.