### PR TITLE
feat(categories): implement full CRUD for campaign categories

### DIFF
--- a/app/Http/Controllers/Api/CampaignCategoryController.php
+++ b/app/Http/Controllers/Api/CampaignCategoryController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreCampaignCategoryRequest;
+use App\Http\Requests\Api\UpdateCampaignCategoryRequest;
+use App\Http\Resources\CampaignCategoryResource;
 use App\Services\Interfaces\CampaignCategoryServiceInterface;
 use App\Traits\ApiResponse;
 use Illuminate\Http\JsonResponse;
@@ -31,7 +34,25 @@ class CampaignCategoryController extends Controller
         $perPage = $request->query('per_page', 10);
         $categories = $this->categoryService->getAllCategories($perPage);
 
-        return $this->successWithPagination($categories, 'Campaign categories retrieved successfully');
+        return $this->successWithPagination(CampaignCategoryResource::collection($categories), 'Campaign categories retrieved successfully');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param StoreCampaignCategoryRequest $request
+     * @return JsonResponse
+     */
+    public function store(StoreCampaignCategoryRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        if ($request->hasFile('icon')) {
+            $data['icon'] = $request->file('icon');
+        }
+
+        $category = $this->categoryService->createCategory($data);
+
+        return $this->success(new CampaignCategoryResource($category), 'Campaign category created successfully', 201);
     }
 
     /**
@@ -44,9 +65,52 @@ class CampaignCategoryController extends Controller
     {
         try {
             $category = $this->categoryService->getCategoryById($id);
-            return $this->success($category, 'Campaign category retrieved successfully');
+            return $this->success(new CampaignCategoryResource($category), 'Campaign category retrieved successfully');
         } catch (ModelNotFoundException $e) {
             return $this->error($e->getMessage(), 404);
+        } catch (\Exception $e) {
+            return $this->error($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param UpdateCampaignCategoryRequest $request
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function update(UpdateCampaignCategoryRequest $request, int $id): JsonResponse
+    {
+        try {
+            $data = $request->validated();
+            if ($request->hasFile('icon')) {
+                $data['icon'] = $request->file('icon');
+            }
+
+            $category = $this->categoryService->updateCategory($id, $data);
+
+            return $this->success(new CampaignCategoryResource($category), 'Campaign category updated successfully');
+        } catch (ModelNotFoundException $e) {
+            return $this->error("Campaign category with ID {$id} not found.", 404);
+        } catch (\Exception $e) {
+            return $this->error($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $this->categoryService->deleteCategory($id);
+            return $this->success(null, 'Campaign category deleted successfully');
+        } catch (ModelNotFoundException $e) {
+            return $this->error("Campaign category with ID {$id} not found.", 404);
         } catch (\Exception $e) {
             return $this->error($e->getMessage(), 500);
         }
@@ -65,6 +129,6 @@ class CampaignCategoryController extends Controller
         
         $categories = $this->categoryService->searchCategories($keyword, $perPage);
 
-        return $this->successWithPagination($categories, 'Campaign categories search results retrieved successfully');
+        return $this->successWithPagination(CampaignCategoryResource::collection($categories), 'Campaign categories search results retrieved successfully');
     }
 }

--- a/app/Http/Requests/Api/StoreCampaignCategoryRequest.php
+++ b/app/Http/Requests/Api/StoreCampaignCategoryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Http\Requests\BaseRequest;
+
+class StoreCampaignCategoryRequest extends BaseRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:100',
+            'slug' => 'required|string|max:100|unique:campaign_categories,slug',
+            'icon' => 'nullable|image|mimes:jpeg,png,jpg,webp,svg|max:1024',
+            'is_active' => 'boolean',
+            'order_index' => 'integer',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateCampaignCategoryRequest.php
+++ b/app/Http/Requests/Api/UpdateCampaignCategoryRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Http\Requests\BaseRequest;
+
+class UpdateCampaignCategoryRequest extends BaseRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $id = $this->route('campaign_category');
+
+        return [
+            'name' => 'sometimes|required|string|max:100',
+            'slug' => 'sometimes|required|string|max:100|unique:campaign_categories,slug,' . $id,
+            'icon' => 'nullable|image|mimes:jpeg,png,jpg,webp,svg|max:1024',
+            'is_active' => 'boolean',
+            'order_index' => 'integer',
+        ];
+    }
+}

--- a/app/Http/Resources/CampaignCategoryResource.php
+++ b/app/Http/Resources/CampaignCategoryResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CampaignCategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'icon_url' => $this->icon_url,
+            'is_active' => $this->is_active,
+            'order_index' => $this->order_index,
+        ];
+    }
+}

--- a/app/Models/CampaignCategory.php
+++ b/app/Models/CampaignCategory.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CampaignCategory extends Model
 {
+    use HasFactory;
+
     public $timestamps = false;
 
     protected $fillable = [

--- a/app/Repositories/Implementations/CampaignCategoryRepository.php
+++ b/app/Repositories/Implementations/CampaignCategoryRepository.php
@@ -33,4 +33,31 @@ class CampaignCategoryRepository implements CampaignCategoryRepositoryInterface
             ->orWhere('slug', 'like', "%{$keyword}%")
             ->paginate($perPage);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $data): CampaignCategory
+    {
+        return CampaignCategory::create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(int $id, array $data): CampaignCategory
+    {
+        $category = CampaignCategory::findOrFail($id);
+        $category->update($data);
+        return $category;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(int $id): bool
+    {
+        $category = CampaignCategory::findOrFail($id);
+        return $category->delete();
+    }
 }

--- a/app/Repositories/Interfaces/CampaignCategoryRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CampaignCategoryRepositoryInterface.php
@@ -31,4 +31,29 @@ interface CampaignCategoryRepositoryInterface
      * @return LengthAwarePaginator
      */
     public function search(string $keyword, int $perPage): LengthAwarePaginator;
+
+    /**
+     * Create a new category.
+     *
+     * @param array $data
+     * @return CampaignCategory
+     */
+    public function create(array $data): CampaignCategory;
+
+    /**
+     * Update an existing category.
+     *
+     * @param int $id
+     * @param array $data
+     * @return CampaignCategory
+     */
+    public function update(int $id, array $data): CampaignCategory;
+
+    /**
+     * Delete a category.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function delete(int $id): bool;
 }

--- a/app/Services/Implementations/CampaignCategoryService.php
+++ b/app/Services/Implementations/CampaignCategoryService.php
@@ -7,6 +7,9 @@ use App\Repositories\Interfaces\CampaignCategoryRepositoryInterface;
 use App\Services\Interfaces\CampaignCategoryServiceInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
 
 class CampaignCategoryService implements CampaignCategoryServiceInterface
 {
@@ -45,5 +48,70 @@ class CampaignCategoryService implements CampaignCategoryServiceInterface
     public function searchCategories(string $keyword, int $perPage): LengthAwarePaginator
     {
         return $this->categoryRepository->search($keyword, $perPage);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createCategory(array $data): CampaignCategory
+    {
+        if (isset($data['icon']) && $data['icon'] instanceof UploadedFile) {
+            $filename = Str::uuid() . '.' . $data['icon']->getClientOriginalExtension();
+            $path = $data['icon']->storeAs('categories', $filename, 'r2');
+            $data['icon_url'] = Storage::disk('r2')->url($path);
+            unset($data['icon']);
+        }
+
+        return $this->categoryRepository->create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateCategory(int $id, array $data): CampaignCategory
+    {
+        if (isset($data['icon']) && $data['icon'] instanceof UploadedFile) {
+            $category = $this->getCategoryById($id);
+            if ($category->icon_url) {
+                $this->deleteFileFromR2($category->icon_url);
+            }
+
+            $filename = Str::uuid() . '.' . $data['icon']->getClientOriginalExtension();
+            $path = $data['icon']->storeAs('categories', $filename, 'r2');
+            $data['icon_url'] = Storage::disk('r2')->url($path);
+            unset($data['icon']);
+        }
+
+        return $this->categoryRepository->update($id, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteCategory(int $id): bool
+    {
+        $category = $this->getCategoryById($id);
+        if ($category->icon_url) {
+            $this->deleteFileFromR2($category->icon_url);
+        }
+
+        return $this->categoryRepository->delete($id);
+    }
+
+    /**
+     * Delete file from R2 by URL.
+     *
+     * @param string $url
+     * @return void
+     */
+    protected function deleteFileFromR2(string $url): void
+    {
+        $baseUrl = Storage::disk('r2')->url('');
+        $path = str_replace($baseUrl, '', $url);
+        $path = ltrim($path, '/');
+        
+        if ($path) {
+            Storage::disk('r2')->delete($path);
+        }
     }
 }

--- a/app/Services/Interfaces/CampaignCategoryServiceInterface.php
+++ b/app/Services/Interfaces/CampaignCategoryServiceInterface.php
@@ -31,4 +31,29 @@ interface CampaignCategoryServiceInterface
      * @return LengthAwarePaginator
      */
     public function searchCategories(string $keyword, int $perPage): LengthAwarePaginator;
+
+    /**
+     * Create a new category.
+     *
+     * @param array $data
+     * @return CampaignCategory
+     */
+    public function createCategory(array $data): CampaignCategory;
+
+    /**
+     * Update an existing category.
+     *
+     * @param int $id
+     * @param array $data
+     * @return CampaignCategory
+     */
+    public function updateCategory(int $id, array $data): CampaignCategory;
+
+    /**
+     * Delete a category.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function deleteCategory(int $id): bool;
 }

--- a/database/factories/CampaignCategoryFactory.php
+++ b/database/factories/CampaignCategoryFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CampaignCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class CampaignCategoryFactory extends Factory
+{
+    protected $model = CampaignCategory::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'icon_url' => $this->faker->imageUrl(),
+            'is_active' => true,
+            'order_index' => $this->faker->numberBetween(0, 100),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,13 @@ Route::prefix('auth')->group(function () {
             Route::put('/{banner}', [BannerController::class, 'update']);
             Route::delete('/{banner}', [BannerController::class, 'destroy']);
         });
+
+        // Campaign Categories
+        Route::prefix('campaign-categories')->group(function () {
+            Route::post('/', [CampaignCategoryController::class, 'store']);
+            Route::put('/{campaign_category}', [CampaignCategoryController::class, 'update']);
+            Route::delete('/{campaign_category}', [CampaignCategoryController::class, 'destroy']);
+        });
     });
 });
 

--- a/tests/Feature/CampaignCategoryTest.php
+++ b/tests/Feature/CampaignCategoryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use App\Models\CampaignCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class CampaignCategoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_categories()
+    {
+        CampaignCategory::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/campaign-categories');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['id', 'name', 'slug', 'icon_url', 'is_active', 'order_index']
+                ]
+            ]);
+    }
+
+    public function test_admin_can_create_category_with_r2_upload()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $file = UploadedFile::fake()->image('icon.png');
+        $data = [
+            'name' => 'Education',
+            'slug' => 'education',
+            'icon' => $file,
+            'is_active' => true,
+        ];
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->postJson('/api/auth/campaign-categories', $data);
+
+        $response->assertStatus(201);
+        
+        $category = CampaignCategory::first();
+        $this->assertNotNull($category->icon_url);
+        
+        $filename = basename($category->icon_url);
+        Storage::disk('r2')->assertExists('categories/' . $filename);
+    }
+
+    public function test_admin_can_update_category_with_new_icon()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $category = CampaignCategory::factory()->create([
+            'icon_url' => 'https://example.com/old.png'
+        ]);
+
+        $file = UploadedFile::fake()->image('new_icon.png');
+        $data = [
+            'name' => 'Updated Category',
+            'icon' => $file,
+        ];
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->putJson("/api/auth/campaign-categories/{$category->id}", $data);
+
+        $response->assertStatus(200);
+        
+        $category->refresh();
+        $this->assertEquals('Updated Category', $category->name);
+        $this->assertStringContainsString('.png', $category->icon_url);
+        
+        $filename = basename($category->icon_url);
+        Storage::disk('r2')->assertExists('categories/' . $filename);
+    }
+
+    public function test_admin_can_delete_category_and_icon_from_r2()
+    {
+        Storage::fake('r2');
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $path = 'categories/test.png';
+        Storage::disk('r2')->put($path, 'content');
+        $url = Storage::disk('r2')->url($path);
+
+        $category = CampaignCategory::factory()->create([
+            'icon_url' => $url,
+        ]);
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->deleteJson("/api/auth/campaign-categories/{$category->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('campaign_categories', ['id' => $category->id]);
+        Storage::disk('r2')->assertMissing($path);
+    }
+}

--- a/tests/Unit/Http/Controllers/Api/CampaignCategoryControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CampaignCategoryControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Http\Controllers\Api;
+
+use App\Models\Admin;
+use App\Models\CampaignCategory;
+use App\Services\Interfaces\CampaignCategoryServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Mockery\MockInterface;
+use Mockery;
+use Tests\TestCase;
+
+class CampaignCategoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_success_response()
+    {
+        $this->mock(CampaignCategoryServiceInterface::class, function (MockInterface $mock) {
+            $paginator = new LengthAwarePaginator(collect([]), 0, 10);
+            $mock->shouldReceive('getAllCategories')->once()->with(10)->andReturn($paginator);
+        });
+
+        $response = $this->getJson('/api/campaign-categories?per_page=10');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'Campaign categories retrieved successfully'
+            ]);
+    }
+
+    public function test_show_returns_success_response()
+    {
+        $category = new CampaignCategory(['id' => 1, 'name' => 'Health', 'slug' => 'health']);
+        $category->id = 1;
+
+        $this->mock(CampaignCategoryServiceInterface::class, function (MockInterface $mock) use ($category) {
+            $mock->shouldReceive('getCategoryById')->once()->with(1)->andReturn($category);
+        });
+
+        $response = $this->getJson('/api/campaign-categories/1');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    'id' => 1,
+                    'name' => 'Health'
+                ]
+            ]);
+    }
+
+    public function test_store_returns_success_response()
+    {
+        $admin = Admin::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+        ]);
+        
+        $category = new CampaignCategory(['id' => 1, 'name' => 'Education', 'slug' => 'education']);
+        $category->id = 1;
+
+        $this->mock(CampaignCategoryServiceInterface::class, function (MockInterface $mock) use ($category) {
+            $mock->shouldReceive('createCategory')->once()->andReturn($category);
+        });
+
+        $response = $this->actingAs($admin, 'admin-api')
+            ->postJson('/api/auth/campaign-categories', [
+                'name' => 'Education',
+                'slug' => 'education'
+            ]);
+
+        $response->assertStatus(201);
+    }
+}

--- a/tests/Unit/Services/CampaignCategoryServiceTest.php
+++ b/tests/Unit/Services/CampaignCategoryServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\CampaignCategory;
+use App\Repositories\Interfaces\CampaignCategoryRepositoryInterface;
+use App\Services\Implementations\CampaignCategoryService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class CampaignCategoryServiceTest extends TestCase
+{
+    public function test_create_category_uploads_to_r2()
+    {
+        Storage::fake('r2');
+        $file = UploadedFile::fake()->image('icon.png');
+        
+        $data = [
+            'name' => 'Test Category',
+            'icon' => $file
+        ];
+
+        $capturedData = [];
+        $this->mock(CampaignCategoryRepositoryInterface::class, function (MockInterface $mock) use (&$capturedData) {
+            $mock->shouldReceive('create')
+                ->once()
+                ->with(Mockery::on(function($arg) use (&$capturedData) {
+                    $capturedData = $arg;
+                    return $arg['name'] === 'Test Category' && isset($arg['icon_url']);
+                }))
+                ->andReturn(new CampaignCategory());
+        });
+
+        $service = app(CampaignCategoryService::class);
+        $service->createCategory($data);
+        
+        $filename = basename($capturedData['icon_url']);
+        Storage::disk('r2')->assertExists('categories/' . $filename);
+    }
+
+    public function test_get_all_categories_returns_paginated_data()
+    {
+        $perPage = 10;
+        $mockPaginator = Mockery::mock(LengthAwarePaginator::class);
+
+        $this->mock(CampaignCategoryRepositoryInterface::class, function (MockInterface $mock) use ($mockPaginator, $perPage) {
+            $mock->shouldReceive('getAllPaginated')->once()->with($perPage)->andReturn($mockPaginator);
+        });
+
+        $service = app(CampaignCategoryService::class);
+        $result = $service->getAllCategories($perPage);
+
+        $this->assertSame($mockPaginator, $result);
+    }
+
+    public function test_delete_category_calls_repository_and_removes_file()
+    {
+        Storage::fake('r2');
+        $path = 'categories/test.png';
+        Storage::disk('r2')->put($path, 'content');
+        $url = Storage::disk('r2')->url($path);
+
+        $category = new CampaignCategory(['id' => 1, 'icon_url' => $url]);
+
+        $this->mock(CampaignCategoryRepositoryInterface::class, function (MockInterface $mock) use ($category) {
+            $mock->shouldReceive('findById')->andReturn($category);
+            $mock->shouldReceive('delete')->once()->with(1)->andReturn(true);
+        });
+
+        $service = app(CampaignCategoryService::class);
+        $service->deleteCategory(1);
+
+        Storage::disk('r2')->assertMissing($path);
+    }
+}


### PR DESCRIPTION
## Description
Implemented full CRUD functionality for Campaign Categories with Cloudflare R2 integration for icon storage.

## Changes
- Implemented CampaignCategoryRepository and CampaignCategoryService with R2 upload/delete logic.
- Implemented CampaignCategoryController with CampaignCategoryResource and Store/UpdateCampaignCategoryRequest.
- Added UUID-based filenames for uploaded icons.
- Ensured automatic deletion of old icons on update/delete.
- Added CampaignCategoryFactory for testing.

## Testing
- **Feature Tests**: 	ests/Feature/CampaignCategoryTest.php (Integration with R2 fake storage).
- **Unit Tests (Service)**: 	ests/Unit/Services/CampaignCategoryServiceTest.php (Mocked repository).
- **Unit Tests (Controller)**: 	ests/Unit/Http/Controllers/Api/CampaignCategoryControllerTest.php (Mocked service).
- Total tests passing: 67.