### PR TITLE
feat: implement OTP-based authentication for admin login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,3 +102,5 @@ GOOGLE_REDIRECT_URI="${APP_URL}/auth/user/google/callback"
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI="${APP_URL}/auth/user/github/callback"
+
+RESEND_API_KEY=re_xxx

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -8,6 +8,7 @@ use App\Services\Interfaces\AuthServiceInterface;
 use App\Traits\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use App\Http\Requests\Api\AdminOtpRequest;
 
 class AuthController extends Controller
 {
@@ -21,7 +22,21 @@ class AuthController extends Controller
     }
 
     /**
+     * Request OTP for admin login.
+     *
+     * @param AdminOtpRequest $request
+     * @return JsonResponse
+     */
+    public function requestOtp(AdminOtpRequest $request): JsonResponse
+    {
+        $this->authService->requestOtp($request->validated());
+
+        return $this->success(null, 'OTP sent successfully to your email');
+    }
+
+    /**
      * Admin login.
+...
      *
      * @param LoginRequest $request
      * @return JsonResponse

--- a/app/Http/Requests/Api/AdminOtpRequest.php
+++ b/app/Http/Requests/Api/AdminOtpRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Http\Requests\BaseRequest;
+
+class AdminOtpRequest extends BaseRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email|exists:admins,email',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'email.exists' => 'Admin account with this email not found.',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/LoginRequest.php
+++ b/app/Http/Requests/Api/LoginRequest.php
@@ -15,7 +15,7 @@ class LoginRequest extends BaseRequest
     {
         return [
             'email' => 'required|email',
-            'password' => 'required|string',
+            'otp' => 'required|string|size:6',
         ];
     }
 }

--- a/app/Mail/AdminOtpMail.php
+++ b/app/Mail/AdminOtpMail.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AdminOtpMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public string $otp
+    ) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Admin Login OTP - ' . config('app.name'),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.admin-otp',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Services/Implementations/AuthService.php
+++ b/app/Services/Implementations/AuthService.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Auth\AuthenticationException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\AdminOtpMail;
+
 class AuthService implements AuthServiceInterface
 {
     protected AuthRepositoryInterface $authRepository;
@@ -26,13 +30,22 @@ class AuthService implements AuthServiceInterface
     {
         $admin = $this->authRepository->findAdminByEmail($credentials['email']);
 
-        if (!$admin || !Hash::check($credentials['password'], $admin->password)) {
+        if (!$admin) {
             abort(401, 'Invalid credentials.');
         }
 
         if (!$admin->is_active) {
             abort(401, 'Account is inactive.');
         }
+
+        $otp = Redis::get('otp:' . $credentials['email']);
+
+        if (!$otp || $otp !== $credentials['otp']) {
+            abort(422, 'Invalid or expired OTP.');
+        }
+
+        // Invalidate OTP after successful use
+        Redis::del('otp:' . $credentials['email']);
 
         $this->authRepository->updateAdminLastLogin($admin);
 
@@ -42,6 +55,32 @@ class AuthService implements AuthServiceInterface
             'admin' => $admin,
             'token' => $token,
         ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function requestOtp(array $data): void
+    {
+        $admin = $this->authRepository->findAdminByEmail($data['email']);
+
+        if (!$admin) {
+            // We return early to avoid email enumeration, but in some cases you might want to return an error.
+            // However, based on the requirements, we'll just check if admin exists.
+            abort(404, 'Admin not found.');
+        }
+
+        if (!$admin->is_active) {
+            abort(401, 'Account is inactive.');
+        }
+
+        $otp = (string) rand(100000, 999999);
+
+        // Store OTP in Redis with 5 minutes TTL
+        Redis::setex('otp:' . $data['email'], 300, $otp);
+
+        // Send OTP via email
+        Mail::to($admin->email)->send(new AdminOtpMail($otp));
     }
 
     /**

--- a/app/Services/Interfaces/AuthServiceInterface.php
+++ b/app/Services/Interfaces/AuthServiceInterface.php
@@ -13,6 +13,14 @@ interface AuthServiceInterface
     public function adminLogin(array $credentials): array;
 
     /**
+     * Request OTP for admin login.
+     *
+     * @param array $data
+     * @return void
+     */
+    public function requestOtp(array $data): void;
+
+    /**
      * Authenticate a user via OAuth.
      *
      * @param string $provider

--- a/resources/views/emails/admin-otp.blade.php
+++ b/resources/views/emails/admin-otp.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+    <p>Halo Admin,</p>
+    
+    <p>Berikut adalah kode OTP Anda untuk masuk ke dashboard admin:</p>
+    
+    <h2 style="font-size: 24px; font-weight: bold; letter-spacing: 5px;">{{ $otp }}</h2>
+    
+    <p>Kode ini akan kadaluwarsa dalam 5 menit.</p>
+    
+    <p>Jika Anda tidak merasa melakukan permintaan ini, silakan abaikan email ini.</p>
+    
+    <p>Salam,<br>Tim Fundraiser</p>
+</body>
+</html>

--- a/resources/views/emails/admin-otp.blade.php
+++ b/resources/views/emails/admin-otp.blade.php
@@ -2,18 +2,49 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body>
-    <p>Halo Admin,</p>
-    
-    <p>Berikut adalah kode OTP Anda untuk masuk ke dashboard admin:</p>
-    
-    <h2 style="font-size: 24px; font-weight: bold; letter-spacing: 5px;">{{ $otp }}</h2>
-    
-    <p>Kode ini akan kadaluwarsa dalam 5 menit.</p>
-    
-    <p>Jika Anda tidak merasa melakukan permintaan ini, silakan abaikan email ini.</p>
-    
-    <p>Salam,<br>Tim Fundraiser</p>
+<body style="margin:0;padding:0;background:#F3F4F6;font-family:'Segoe UI',Arial,sans-serif;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background:#F3F4F6;padding:40px 0;">
+        <tr>
+            <td align="center">
+                <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+
+                    <tr>
+                        <td style="background:#1677ff;padding:40px;text-align:center;">
+                            <h1 style="margin:0;color:#ffffff;font-size:26px;font-weight:700;letter-spacing:0.5px;">Fundraiser</h1>
+                            <p style="margin:8px 0 0;color:#bfdbfe;font-size:14px;">Admin Dashboard</p>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding:40px;">
+                            <p style="margin:0 0 8px;color:#111827;font-size:16px;">Halo, <strong>Admin</strong>,</p>
+                            <p style="margin:0 0 32px;color:#6B7280;font-size:15px;line-height:1.6;">
+                                Gunakan kode OTP berikut untuk masuk ke dashboard admin. Kode ini hanya berlaku selama <strong>5 menit</strong>.
+                            </p>
+
+                            <div style="background:#F0F7FF;border:2px dashed #1677ff;border-radius:12px;padding:32px;text-align:center;margin-bottom:32px;">
+                                <p style="margin:0 0 8px;color:#6B7280;font-size:13px;text-transform:uppercase;letter-spacing:1px;font-weight:600;">Kode OTP Anda</p>
+                                <h2 style="margin:0;font-size:42px;font-weight:800;letter-spacing:12px;color:#1677ff;">{{ $otp }}</h2>
+                            </div>
+
+                            <p style="margin:0;color:#6B7280;font-size:14px;line-height:1.6;">
+                                Jika Anda tidak merasa melakukan permintaan ini, abaikan email ini dan pastikan akun Anda aman.
+                            </p>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="background:#F9FAFB;border-top:1px solid #E5E7EB;padding:24px 40px;text-align:center;">
+                            <p style="margin:0;color:#9CA3AF;font-size:12px;">© 2026 Fundraiser. All rights reserved.</p>
+                            <p style="margin:8px 0 0;color:#9CA3AF;font-size:12px;">This is an automated email. Please do not reply.</p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
 </body>
 </html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -96,7 +96,8 @@ Route::prefix('admin')->middleware('auth:admin-api')->group(function () {
 
 // User Auth Routes
 Route::prefix('auth')->group(function () {
-    Route::post('login', [AuthController::class, 'adminLogin']); // Legacy/Admin login
+    Route::post('otp', [AuthController::class, 'requestOtp']);
+    Route::post('login', [AuthController::class, 'adminLogin']); // Admin OTP login
 
     Route::middleware('auth:api')->group(function () {
         // Dashboard

--- a/tests/Feature/AdminAuthTest.php
+++ b/tests/Feature/AdminAuthTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Redis;
+use App\Mail\AdminOtpMail;
+use Tests\TestCase;
+
+class AdminAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = Admin::create([
+            'name' => 'Admin Test',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_admin_can_request_otp()
+    {
+        Mail::fake();
+        Redis::shouldReceive('setex')
+            ->once()
+            ->withArgs(function ($key, $ttl, $value) {
+                return $key === 'otp:admin@example.com' && $ttl === 300 && strlen($value) === 6;
+            });
+
+        $response = $this->postJson('/api/auth/otp', [
+            'email' => 'admin@example.com',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'OTP sent successfully to your email',
+            ]);
+
+        Mail::assertSent(AdminOtpMail::class, function ($mail) {
+            return $mail->hasTo('admin@example.com');
+        });
+    }
+
+    public function test_admin_cannot_request_otp_with_invalid_email()
+    {
+        $response = $this->postJson('/api/auth/otp', [
+            'email' => 'notfound@example.com',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_admin_can_login_with_valid_otp()
+    {
+        Redis::shouldReceive('get')
+            ->once()
+            ->with('otp:admin@example.com')
+            ->andReturn('123456');
+
+        Redis::shouldReceive('del')
+            ->once()
+            ->with('otp:admin@example.com');
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'admin@example.com',
+            'otp' => '123456',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'admin',
+                    'token',
+                ],
+                'message',
+            ]);
+    }
+
+    public function test_admin_cannot_login_with_invalid_otp()
+    {
+        Redis::shouldReceive('get')
+            ->once()
+            ->with('otp:admin@example.com')
+            ->andReturn('123456');
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'admin@example.com',
+            'otp' => '000000',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Invalid or expired OTP.',
+            ]);
+    }
+
+    public function test_admin_cannot_login_with_expired_otp()
+    {
+        Redis::shouldReceive('get')
+            ->once()
+            ->with('otp:admin@example.com')
+            ->andReturn(null);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'admin@example.com',
+            'otp' => '123456',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'Invalid or expired OTP.',
+            ]);
+    }
+}

--- a/tests/Unit/Http/Controllers/Api/AuthControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/AuthControllerTest.php
@@ -9,11 +9,33 @@ use Mockery;
 use Mockery\MockInterface;
 use Tests\TestCase;
 
+use App\Http\Requests\Api\AdminOtpRequest;
+
 class AuthControllerTest extends TestCase
 {
+    public function test_request_otp_success()
+    {
+        $data = ['email' => 'admin@test.com'];
+        
+        $request = Mockery::mock(AdminOtpRequest::class);
+        $request->shouldReceive('validated')->once()->andReturn($data);
+
+        $this->mock(AuthServiceInterface::class, function (MockInterface $mock) use ($data) {
+            $mock->shouldReceive('requestOtp')
+                ->once()
+                ->with($data);
+        });
+
+        $controller = app(AuthController::class);
+        $response = $controller->requestOtp($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('OTP sent successfully to your email', $response->getContent());
+    }
+
     public function test_admin_login_success()
     {
-        $credentials = ['email' => 'admin@test.com', 'password' => 'password'];
+        $credentials = ['email' => 'admin@test.com', 'otp' => '123456'];
         
         $request = Mockery::mock(LoginRequest::class);
         $request->shouldReceive('validated')->once()->andReturn($credentials);

--- a/tests/Unit/Services/AuthServiceTest.php
+++ b/tests/Unit/Services/AuthServiceTest.php
@@ -21,10 +21,18 @@ class AuthServiceTest extends TestCase
     {
         $admin = new Admin([
             'email' => 'admin@test.com',
-            'password' => Hash::make('password'),
             'is_active' => true
         ]);
         $admin->id = 1;
+
+        \Illuminate\Support\Facades\Redis::shouldReceive('get')
+            ->once()
+            ->with('otp:admin@test.com')
+            ->andReturn('123456');
+
+        \Illuminate\Support\Facades\Redis::shouldReceive('del')
+            ->once()
+            ->with('otp:admin@test.com');
 
         $this->mock(AuthRepositoryInterface::class, function (MockInterface $mock) use ($admin) {
             $mock->shouldReceive('findAdminByEmail')->with('admin@test.com')->andReturn($admin);
@@ -32,7 +40,7 @@ class AuthServiceTest extends TestCase
         });
 
         $service = app(AuthService::class);
-        $result = $service->adminLogin(['email' => 'admin@test.com', 'password' => 'password']);
+        $result = $service->adminLogin(['email' => 'admin@test.com', 'otp' => '123456']);
 
         $this->assertArrayHasKey('token', $result);
         $this->assertEquals('admin@test.com', $result['admin']->email);


### PR DESCRIPTION
This PR implements OTP-based authentication for admin login as requested in #26.

Key changes:
- New endpoint POST /api/auth/otp to request a 6-digit OTP.
- Updated POST /api/auth/login to require email and otp instead of password.
- OTPs are stored in Redis with a 300s TTL.
- OTPs are invalidated immediately after successful use.
- Integrated with Resend for email delivery.
- Comprehensive tests added and updated.

Closes #26