### PR TITLE
feat: add Cloudflare Turnstile verification on admin OTP request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,9 @@ MIDTRANS_IS_PRODUCTION=false
 MIDTRANS_IS_SANITIZED=true
 MIDTRANS_IS_3DS=true
 
+# Turnstile Configuration
+TURNSTILE_SECRET_KEY=
+
 # Frontend Redirects
 FRONTEND_DONATION_REDIRECT_URL=http://localhost:3000/donation/finish
 

--- a/app/Http/Requests/Api/AdminOtpRequest.php
+++ b/app/Http/Requests/Api/AdminOtpRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api;
 
 use App\Http\Requests\BaseRequest;
+use App\Rules\Turnstile;
 
 class AdminOtpRequest extends BaseRequest
 {
@@ -15,6 +16,7 @@ class AdminOtpRequest extends BaseRequest
     {
         return [
             'email' => 'required|email|exists:admins,email',
+            'cf_turnstile_response' => ['required', new Turnstile],
         ];
     }
 

--- a/app/Rules/Turnstile.php
+++ b/app/Rules/Turnstile.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Http;
+
+class Turnstile implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (empty($value)) {
+            $fail('The Turnstile token is required.');
+            return;
+        }
+
+        $response = Http::asForm()->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+            'secret' => config('services.turnstile.key'),
+            'response' => $value,
+            'remoteip' => request()->ip(),
+        ]);
+
+        if (!$response->successful() || !$response->json('success')) {
+            $fail('Security check failed. Please try again.');
+        }
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -22,6 +22,10 @@ return [
         'key' => env('RESEND_API_KEY'),
     ],
 
+    'turnstile' => [
+        'key' => env('TURNSTILE_SECRET_KEY'),
+    ],
+
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),


### PR DESCRIPTION
## What
Add Cloudflare Turnstile server-side verification to the admin OTP request endpoint to prevent bot spam.

## Changes
- Add `TURNSTILE_SECRET_KEY` to `.env.example`
- Add `turnstile.secret` to `config/services.php`
- Create `TurnstileRules` to verify token via Cloudflare API
- Create custom validation rule `Turnstile`
- Apply validation on `requestOtp` endpoint

Closes #30