### PR TITLE
fix: user dashboard statistics query calculations with days filter

### DIFF
--- a/app/Http/Controllers/Api/DashboardController.php
+++ b/app/Http/Controllers/Api/DashboardController.php
@@ -28,10 +28,13 @@ class DashboardController extends Controller
     /**
      * Get dashboard data for authenticated user.
      */
-    public function userIndex(): JsonResponse
+    public function userIndex(\Illuminate\Http\Request $request): JsonResponse
     {
         $userId = Auth::id();
-        $data = $this->dashboardService->getUserDashboardData($userId);
+        $days = $request->query('days');
+        $daysVal = ($days === 'all' || !$days) ? null : (int) $days;
+        
+        $data = $this->dashboardService->getUserDashboardData($userId, $daysVal);
         return $this->success($data, 'User dashboard statistics retrieved successfully');
     }
 }

--- a/app/Repositories/Implementations/StatRepository.php
+++ b/app/Repositories/Implementations/StatRepository.php
@@ -22,20 +22,28 @@ class StatRepository implements StatRepositoryInterface
         ];
     }
 
-    public function getUserStats(int $userId): array
+    public function getUserStats(int $userId, ?int $days = null): array
     {
         $campaignIds = Campaign::where('user_id', $userId)->pluck('id');
 
+        $raisedQuery = Donation::whereIn('campaign_id', $campaignIds)->where('status', 'success');
+        $donationsQuery = Donation::where('user_id', $userId)->where('status', 'success');
+
+        if ($days) {
+            $dateLimit = now()->subDays($days);
+            $raisedQuery->where('created_at', '>=', $dateLimit);
+            $donationsQuery->where('created_at', '>=', $dateLimit);
+        }
+
+        $raisedSum = (int) $raisedQuery->sum('amount');
+
         return [
-            'total_raised_amount' => (int) Donation::whereIn('campaign_id', $campaignIds)
-                ->where('status', 'success')
-                ->sum('amount'),
-            'total_donors_count' => Donation::whereIn('campaign_id', $campaignIds)
-                ->where('status', 'success')
-                ->count(),
-            'active_campaigns_count' => Campaign::where('user_id', $userId)
-                ->where('status', 'active')
-                ->count(),
+            'total_raised_amount' => $raisedSum,
+            'total_collected_amount' => $raisedSum,
+            'total_donors_count' => $raisedQuery->count(),
+            'active_campaigns_count' => Campaign::where('user_id', $userId)->where('status', 'active')->count(),
+            'total_donations' => $donationsQuery->count(),
+            'total_donated_amount' => (int) $donationsQuery->sum('amount'),
         ];
     }
 

--- a/app/Repositories/Interfaces/StatRepositoryInterface.php
+++ b/app/Repositories/Interfaces/StatRepositoryInterface.php
@@ -12,7 +12,7 @@ interface StatRepositoryInterface
     /**
      * Get donation stats for a user (as creator).
      */
-    public function getUserStats(int $userId): array;
+    public function getUserStats(int $userId, ?int $days = null): array;
 
     /**
      * Get donation chart data (daily sums) for a period.

--- a/app/Services/Implementations/DashboardService.php
+++ b/app/Services/Implementations/DashboardService.php
@@ -38,9 +38,9 @@ class DashboardService implements DashboardServiceInterface
         ];
     }
 
-    public function getUserDashboardData(int $userId): array
+    public function getUserDashboardData(int $userId, ?int $days = null): array
     {
-        $stats = $this->statRepository->getUserStats($userId);
+        $stats = $this->statRepository->getUserStats($userId, $days);
         
         return [
             'overview' => $stats,

--- a/app/Services/Interfaces/DashboardServiceInterface.php
+++ b/app/Services/Interfaces/DashboardServiceInterface.php
@@ -12,5 +12,5 @@ interface DashboardServiceInterface
     /**
      * Get full user dashboard data.
      */
-    public function getUserDashboardData(int $userId): array;
+    public function getUserDashboardData(int $userId, ?int $days = null): array;
 }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -66,8 +66,109 @@ class DashboardTest extends TestCase
                         'total_raised_amount' => 50000,
                         'total_donors_count' => 1,
                         'active_campaigns_count' => 1,
+                        'total_collected_amount' => 50000,
+                        'total_donations' => 0,
+                        'total_donated_amount' => 0,
+                    ]
+                ]
+            ]);
+    }
+
+    public function test_user_can_filter_dashboard_stats_by_days()
+    {
+        $user = User::factory()->create();
+        
+        // Create campaign for this user
+        $campaign = Campaign::factory()->create(['user_id' => $user->id, 'status' => 'active']);
+        
+        // Donation inside 7 days
+        Donation::factory()->create([
+            'campaign_id' => $campaign->id, 
+            'status' => 'success', 
+            'amount' => 50000,
+            'created_at' => now()->subDays(2)
+        ]);
+
+        // Donation outside 7 days but inside 30 days
+        Donation::factory()->create([
+            'campaign_id' => $campaign->id, 
+            'status' => 'success', 
+            'amount' => 100000,
+            'created_at' => now()->subDays(15)
+        ]);
+
+        // Donation made by the user inside 7 days
+        $otherCampaign = Campaign::factory()->create(['status' => 'active']);
+        Donation::factory()->create([
+            'user_id' => $user->id,
+            'campaign_id' => $otherCampaign->id,
+            'status' => 'success',
+            'amount' => 25000,
+            'created_at' => now()->subDays(3)
+        ]);
+
+        // Donation made by the user outside 7 days but inside 30 days
+        Donation::factory()->create([
+            'user_id' => $user->id,
+            'campaign_id' => $otherCampaign->id,
+            'status' => 'success',
+            'amount' => 75000,
+            'created_at' => now()->subDays(20)
+        ]);
+
+        // Filter: 7 days
+        $response7 = $this->actingAs($user, 'api')
+            ->getJson('/api/auth/dashboard?days=7');
+
+        $response7->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'overview' => [
+                        'total_raised_amount' => 50000,
+                        'total_donors_count' => 1,
+                        'total_collected_amount' => 50000,
+                        'total_donations' => 1,
+                        'total_donated_amount' => 25000,
+                    ]
+                ]
+            ]);
+
+        // Filter: 30 days
+        $response30 = $this->actingAs($user, 'api')
+            ->getJson('/api/auth/dashboard?days=30');
+
+        $response30->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'overview' => [
+                        'total_raised_amount' => 150000,
+                        'total_donors_count' => 2,
+                        'total_collected_amount' => 150000,
+                        'total_donations' => 2,
+                        'total_donated_amount' => 100000,
+                    ]
+                ]
+            ]);
+
+        // Filter: all
+        $responseAll = $this->actingAs($user, 'api')
+            ->getJson('/api/auth/dashboard?days=all');
+
+        $responseAll->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'overview' => [
+                        'total_raised_amount' => 150000,
+                        'total_donors_count' => 2,
+                        'total_collected_amount' => 150000,
+                        'total_donations' => 2,
+                        'total_donated_amount' => 100000,
                     ]
                 ]
             ]);
     }
 }
+


### PR DESCRIPTION
## Description
This PR addresses the user dashboard statistics, ensuring that:
1. User-specific donation statistics (`total_donations`, `total_donated_amount`) are calculated and returned correctly.
2. A new `days` parameter is supported on the `/api/auth/dashboard` endpoint, allowing the user to filter their summary stats by period (e.g. 7 days, 30 days, or all time).
3. Overview data correctly maps campaign raised statistics with the selected timeframe.

## Changes
- Modified `StatRepositoryInterface.php` and `StatRepository.php` to accept a `days` query filter inside `getUserStats(int $userId, ?int $days)`.
- Modified `DashboardController.php`, `DashboardServiceInterface.php`, and `DashboardService.php` to support passing the `days` parameter.
- Updated `DashboardTest.php` with a test case checking the `days` parameter filtering logic.
