### PR TITLE
fix: decode and return attribute_changes when properties is empty

### DIFF
--- a/app/Http/Resources/AuditLogResource.php
+++ b/app/Http/Resources/AuditLogResource.php
@@ -9,6 +9,23 @@ class AuditLogResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
+        $properties = $this->properties;
+        
+        // spatie/laravel-activitylog v5 stores model attribute changes in attribute_changes.
+        // If properties is empty, fall back to attribute_changes.
+        if (
+            ($properties === null || 
+            (is_countable($properties) && count($properties) === 0) || 
+            (method_exists($properties, 'isEmpty') && $properties->isEmpty())) && 
+            !empty($this->attribute_changes)
+        ) {
+            $attributeChanges = $this->attribute_changes;
+            if (is_string($attributeChanges)) {
+                $attributeChanges = json_decode($attributeChanges, true);
+            }
+            $properties = $attributeChanges;
+        }
+
         return [
             'id' => $this->id,
             'log_name' => $this->log_name,
@@ -20,7 +37,7 @@ class AuditLogResource extends JsonResource
                 'name' => $this->causer->name,
                 'type' => basename(str_replace('\\', '/', $this->causer_type)),
             ] : null,
-            'properties' => $this->properties,
+            'properties' => $properties,
             'created_at' => $this->created_at->toDateTimeString(),
         ];
     }


### PR DESCRIPTION
Closes #36

## Description
This PR addresses the issue where audit log properties (change details) appear empty on the admin dashboard for automatically logged events.

## Changes
- Modified `AuditLogResource.php` to detect when the `properties` column is empty and fall back to returning decoded JSON from the `attribute_changes` column instead. This guarantees that model modifications (like creations and updates) tracked via `spatie/laravel-activitylog` version 5 display correctly in the admin dashboard interface.
